### PR TITLE
Add scale invariance and bounds checking

### DIFF
--- a/tests/test_mt2_tombs.py
+++ b/tests/test_mt2_tombs.py
@@ -71,4 +71,23 @@ def test_fuzz():
         result_tombs = mt2_tombs(*args)
 
         numpy.testing.assert_allclose(result_lester, result_tombs, rtol=1e-12)
-        
+
+
+def test_scale_invariance():
+    example_args = numpy.array(
+        (100, 410, 20, 150, -210, -300, -200, 280, 100, 100))
+    example_val = mt2_tombs(*example_args)
+
+    # mt2 scales with its arguments; check over some orders of magnitude.
+    for i in range(-100, 100, 10):
+        scale = 10. ** i
+        computed_val = mt2_tombs(*(example_args * scale))
+        assert computed_val == pytest.approx(example_val * scale)
+
+
+def test_negative_masses():
+    # Any negative mass is unphysical.
+    # These arguments use negative masses to make both initial bounds negative.
+    # Check that the result is neither positive nor an infinite loop.
+    computed_val = mt2_tombs(1, 2, 3, 4, 5, 6, 7, 8, -90, -100)
+    assert not (computed_val > 0)


### PR DESCRIPTION
Teach `mt2_bisect_impl` to divide out the scale to give bigger dynamic range.

Add a check for negative bounds, which can be caused by nasty negative mass inputs.

Add tests for both of these changes.

Make the template float-compatible by changing a couple of literals.

Add some formatting and comments improvments.

Affects issues #42 #43