### PR TITLE
uv publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,8 @@ jobs:
                   path: dist
                   merge-multiple: true
 
-            - uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  password: ${{ secrets.PYPI_API_TOKEN }}
-                  # To test: repository_url: https://test.pypi.org/legacy/
+            - name: Install uv
+              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+            - name: Publish
+              run: uv publish


### PR DESCRIPTION
Use [`uv publish`](https://docs.astral.sh/uv/guides/publish/#publishing-your-package) to push to pypi.

Credentials no longer required as I've [registered the workflow with pypi](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

(Note: this won't be tested in anger until we next make a release.)
