### PR TITLE
Attempt to force use of trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     upload_pypi:
         needs: [pass]
         runs-on: ubuntu-latest
-        environment: pypi
+        environment: moopypi
         permissions:
             # Required for trusted publishing; see https://docs.pypi.org/trusted-publishers/using-a-publisher/
             id-token: write  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
     upload_pypi:
         needs: [pass]
         runs-on: ubuntu-latest
+        environment: pypi
+        permissions:
+            # Required for trusted publishing; see https://docs.pypi.org/trusted-publishers/using-a-publisher/
+            id-token: write  
         # upload to PyPI on every tag starting with 'v'
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
               uses: astral-sh/setup-uv@v4
 
             - name: Publish
-              run: uv publish --trusted-publishing always
+              run: uv publish --trusted-publishing always -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
               uses: astral-sh/setup-uv@v4
 
             - name: Publish
-              run: uv publish
+              run: uv publish --trusted-publishing always


### PR DESCRIPTION
Looking at the failure here, it seems like uv might not be trying to use it, even though it's configured on pypi.

https://github.com/tpgillam/mt2/actions/runs/12402987390/job/34626056980

```
Publishing 41 files https://upload.pypi.org/legacy/
Note: Neither credentials nor keyring are configured, and there was an error fetching the trusted publishing token. If you don't want to use trusted publishing, you can ignore this error, but you need to provide credentials.
Trusted publishing error: Environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN not set, is the `id-token: write` permission missing?
Uploading mt2-1.2.3-cp310-cp310-macosx_10_9_universal2.whl (70.3KiB)
error: Failed to publish `dist/mt2-1.2.3-cp310-cp310-macosx_10_9_universal2.whl` to https://upload.pypi.org/legacy/
  Caused by: Failed to send POST request
  Caused by: Missing credentials for https://upload.pypi.org/legacy/
Error: Process completed with exit code 2.
```

The "error fetching the trusted publishing token" might be indicative of another problem. Let the whack-a-mole commence...