### PR TITLE
Workaround pypa/setuptools#4759

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ urls = { Homepage = "https://github.com/tpgillam/mt2" }
 requires = ["setuptools>=61.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+# FIXME: this is a workaround; see:
+#   - https://github.com/astral-sh/uv/issues/9513
+#   - https://github.com/pypa/setuptools/issues/4759
+license-files = []


### PR DESCRIPTION
https://github.com/tpgillam/mt2/actions/runs/12408409883/job/34640456714

```
DEBUG Received token, using trusted publishing
Uploading mt2-1.2.3-cp310-cp310-macosx_10_9_universal2.whl (70.3KiB)
DEBUG Hashing dist/mt2-1.2.3-cp310-cp310-macosx_10_9_universal2.whl
DEBUG Using username/password basic auth
DEBUG Response code for https://upload.pypi.org/legacy/: 400 Bad Request
DEBUG Upload error response: {"message": "The server could not comply with the request since it is either malformed or otherwise incorrect.\n\n\nlicense-file introduced in metadata version 2.4, not 2.1. See https://packaging.python.org/specifications/core-metadata for more information.\n\n", "code": "400 license-file introduced in metadata version 2.4, not 2.1. See https://packaging.python.org/specifications/core-metadata for more information.", "title": "Bad Request"}
error: Failed to publish `dist/mt2-1.2.3-cp310-cp310-macosx_10_9_universal2.whl` to https://upload.pypi.org/legacy/
  Caused by: Upload failed with status code 400 Bad Request. Server says: 400 license-file introduced in metadata version 2.4, not 2.1. See https://packaging.python.org/specifications/core-metadata for more information.
```

See:
- https://github.com/astral-sh/uv/issues/9513
- https://github.com/pypa/setuptools/issues/4759

Here we implement the workaround suggested in https://github.com/astral-sh/uv/issues/9513. We can't trivially switch build backend right now since we're relying on setuptools to compile our extension module.
