### PR TITLE
Add pyright and dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,10 @@ jobs:
                 python-version: ${{ matrix.python }}
 
             - name: Test
-              run: uv run python -m unittest discover tests
+              run: uv run --no-dev python -m unittest discover tests
 
             - name: Test with oldest-supported-numpy
-              run: |
-                uv pip install oldest-supported-numpy
-                uv run python -m unittest discover tests
+              run: uv run --no-dev --with oldest-supported-numpy python -m unittest discover tests
 
             - name: Static type check
               run: uv run pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
 
             - name: Test with oldest-supported-numpy
               run: |
-                uv pip install oldest-supported-numpy 
+                uv pip install oldest-supported-numpy
                 uv run python -m unittest discover tests
+
+            - name: Static type check
+              run: uv run pyright
 
     build_wheels:
         name: Build wheel for ${{ matrix.os }}-${{ matrix.build }}${{ matrix.python }}-${{ matrix.arch }}
@@ -98,7 +101,7 @@ jobs:
         environment: moopypi
         permissions:
             # Required for trusted publishing; see https://docs.pypi.org/trusted-publishers/using-a-publisher/
-            id-token: write  
+            id-token: write
         # upload to PyPI on every tag starting with 'v'
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
         steps:

--- a/examples/benchmark_comparison.py
+++ b/examples/benchmark_comparison.py
@@ -4,7 +4,7 @@ import numpy
 
 from matplotlib import pyplot
 
-from _mt2 import mt2_lally_ufunc, mt2_lester_ufunc, mt2_tombs_ufunc
+from mt2._mt2 import mt2_lally_ufunc, mt2_lester_ufunc, mt2_tombs_ufunc
 
 
 def mt2_lester(

--- a/examples/plot_constraints.py
+++ b/examples/plot_constraints.py
@@ -5,7 +5,7 @@ from mt2._mt2 import mt2_lally_ufunc
 from mt2.diagnostics import make_ellipses
 
 
-def plot_lester_v_lally(args):
+def plot_lester_v_lally(args: tuple[float, ...]) -> None:
     """Make a plot comparing Lester & Lally algorithms to MT2.
 
     `args` should be a tuple of arguments that would be given to `mt2` or `mt2_lally`.

--- a/examples/plot_constraints.py
+++ b/examples/plot_constraints.py
@@ -1,16 +1,18 @@
 from matplotlib import pyplot
 
-from mt2 import mt2, mt2_lally
+from mt2 import mt2
+from mt2._mt2 import mt2_lally_ufunc
 from mt2.diagnostics import make_ellipses
 
 
 def plot_lester_v_lally(args):
     """Make a plot comparing Lester & Lally algorithms to MT2.
-    
+
     `args` should be a tuple of arguments that would be given to `mt2` or `mt2_lally`.
     """
     m_lester = mt2(*args)
-    m_lally = mt2_lally(*args)
+    desired_precision_on_mt2 = 0.0
+    m_lally = mt2_lally_ufunc(*args, desired_precision_on_mt2)
 
     params_1_lester, params_2_lester = make_ellipses(m_lester, *args)
     params_1_lally, params_2_lally = make_ellipses(m_lally, *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ license-files = []
 
 [dependency-groups]
 dev = [
-    "ipykernel>=6.29.5", # notebooks
+    "ipykernel>=6.29.5",
     "matplotlib>=3.9.4",
-    "pyqt6>=6.8.1", # interactive plots
+    "pyqt6>=6.8.1",
     "pyright==1.1.394",
     "setuptools>=75.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ license-files = []
 dev = [
     "ipykernel>=6.29.5",
     "matplotlib>=3.9.4",
-    "pyqt6>=6.8.1",
     "pyright==1.1.394",
     "setuptools>=75.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,10 @@ build-backend = "setuptools.build_meta"
 #   - https://github.com/astral-sh/uv/issues/9513
 #   - https://github.com/pypa/setuptools/issues/4759
 license-files = []
+
+[dependency-groups]
+dev = [
+    "matplotlib>=3.9.4",
+    "pyright==1.1.394",
+    "setuptools>=75.8.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ license-files = []
 
 [dependency-groups]
 dev = [
+    "ipykernel>=6.29.5", # notebooks
     "matplotlib>=3.9.4",
+    "pyqt6>=6.8.1", # interactive plots
     "pyright==1.1.394",
     "setuptools>=75.8.0",
 ]

--- a/src/mt2/__init__.py
+++ b/src/mt2/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, overload
 
 import numpy
 
@@ -8,7 +8,38 @@ __version__ = "1.2.3"
 
 __all__ = ["mt2", "mt2_arxiv", "mt2_ufunc"]
 
-
+@overload
+def mt2(
+    m_vis_1: float,
+    px_vis_1: float,
+    py_vis_1: float,
+    m_vis_2: float,
+    px_vis_2: float,
+    py_vis_2: float,
+    px_miss: float,
+    py_miss: float,
+    m_invis_1: float,
+    m_invis_2: float,
+    desired_precision_on_mt2: float = 0.0,
+    *,
+    out: None = None
+) -> float: ...
+@overload
+def mt2(
+    m_vis_1: Union[float, numpy.ndarray],
+    px_vis_1: Union[float, numpy.ndarray],
+    py_vis_1: Union[float, numpy.ndarray],
+    m_vis_2: Union[float, numpy.ndarray],
+    px_vis_2: Union[float, numpy.ndarray],
+    py_vis_2: Union[float, numpy.ndarray],
+    px_miss: Union[float, numpy.ndarray],
+    py_miss: Union[float, numpy.ndarray],
+    m_invis_1: Union[float, numpy.ndarray],
+    m_invis_2: Union[float, numpy.ndarray],
+    desired_precision_on_mt2: Union[float, numpy.ndarray] = 0.0,
+    *,
+    out: Optional[numpy.ndarray] = None
+) -> Union[float, numpy.ndarray]: ...
 def mt2(
     m_vis_1: Union[float, numpy.ndarray],
     px_vis_1: Union[float, numpy.ndarray],
@@ -82,6 +113,40 @@ def mt2(
 mt2_ufunc = mt2_tombs_ufunc
 
 
+@overload
+def mt2_arxiv(
+    m_vis_1: float,
+    px_vis_1: float,
+    py_vis_1: float,
+    m_vis_2: float,
+    px_vis_2: float,
+    py_vis_2: float,
+    px_miss: float,
+    py_miss: float,
+    m_invis_1: float,
+    m_invis_2: float,
+    desired_precision_on_mt2: float = 0.0,
+    use_deci_sections_initially: bool = True,
+    *,
+    out: None = None
+) -> float: ...
+@overload
+def mt2_arxiv(
+    m_vis_1: Union[float, numpy.ndarray],
+    px_vis_1: Union[float, numpy.ndarray],
+    py_vis_1: Union[float, numpy.ndarray],
+    m_vis_2: Union[float, numpy.ndarray],
+    px_vis_2: Union[float, numpy.ndarray],
+    py_vis_2: Union[float, numpy.ndarray],
+    px_miss: Union[float, numpy.ndarray],
+    py_miss: Union[float, numpy.ndarray],
+    m_invis_1: Union[float, numpy.ndarray],
+    m_invis_2: Union[float, numpy.ndarray],
+    desired_precision_on_mt2: Union[float, numpy.ndarray] = 0.0,
+    use_deci_sections_initially: Union[bool, numpy.ndarray] = True,
+    *,
+    out: Optional[numpy.ndarray] = None
+) -> Union[float, numpy.ndarray]: ...
 def mt2_arxiv(
     m_vis_1: Union[float, numpy.ndarray],
     px_vis_1: Union[float, numpy.ndarray],

--- a/src/mt2/__init__.py
+++ b/src/mt2/__init__.py
@@ -8,6 +8,7 @@ __version__ = "1.2.3"
 
 __all__ = ["mt2", "mt2_arxiv", "mt2_ufunc"]
 
+
 @overload
 def mt2(
     m_vis_1: float,

--- a/src/mt2/diagnostics.py
+++ b/src/mt2/diagnostics.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Tuple
 
 import numpy
 
@@ -150,16 +150,16 @@ def _make_ellipse_params(
 
 def make_ellipses(
     proposed_mt2: float,
-    m_vis_1: Union[float, numpy.ndarray],
-    px_vis_1: Union[float, numpy.ndarray],
-    py_vis_1: Union[float, numpy.ndarray],
-    m_vis_2: Union[float, numpy.ndarray],
-    px_vis_2: Union[float, numpy.ndarray],
-    py_vis_2: Union[float, numpy.ndarray],
-    px_miss: Union[float, numpy.ndarray],
-    py_miss: Union[float, numpy.ndarray],
-    m_invis_1: Union[float, numpy.ndarray],
-    m_invis_2: Union[float, numpy.ndarray],
+    m_vis_1: float,
+    px_vis_1: float,
+    py_vis_1: float,
+    m_vis_2: float,
+    px_vis_2: float,
+    py_vis_2: float,
+    px_miss: float,
+    py_miss: float,
+    m_invis_1: float,
+    m_invis_2: float,
 ) -> Tuple[EllipseParams, EllipseParams]:
     """
     Make a pair of ellipses in p1x, p1y; the intersection is the feasible region.


### PR DESCRIPTION
- Use `[dependency-groups]` to add pyright.
- Resolve pyright's errors by adding more dev dependencies and tweaking type annotations.
- Run pyright after tests in ci.
